### PR TITLE
Add cache folder

### DIFF
--- a/start-server.sh
+++ b/start-server.sh
@@ -43,10 +43,14 @@ fi
 log "Executing docker run"
 trap "log 'Server stopped' ;warnings" 0
 
+mkdir -p "$SCRIPT_DIR"/webDiplomacyCache
+chmod ugo+rwx "$SCRIPT_DIR"/webDiplomacyCache
+
 # Create volume first by using 'docker volume create webDipData'
 docker run --name webDip -p $WEBDIP_PORT:80 --rm -t -i  \
   --mount type=volume,source=webDipData,dst=/var/lib/mysql \
   -v "$SCRIPT_DIR"/webDiplomacy:/var/www/example.com/public_html \
+  -v "$SCRIPT_DIR"/webDiplomacyCache:/var/www/example.com/public_html/cache \
   -e WEBDIP_PORT=$WEBDIP_PORT \
   -e MYSQL_LOG_CONSOLE=true \
   webdiplomacydev


### PR DESCRIPTION
In some cases webdip server tries to write some stuff to cache folder. Depending on local file permissions, this directory may not be writeable within the docker container, causing the server to fail.

So make an explicit directory for the cache stuff to go into, make it world writeable, and mount it into where the server wants it.